### PR TITLE
fix mcp yaml

### DIFF
--- a/docs/aro-upgrade/README.md
+++ b/docs/aro-upgrade/README.md
@@ -29,6 +29,7 @@ node/testmyaro01-jnlll-worker-japaneast3-6tqgr labeled
 $ : ↓「node-role.kubernetes.io/workerpool-canary=」ラベルが付与されたノードを対象とする
 $ :   OpenShiftのMachineConfigPoolリソースを作成
 $ cat << EOF > worker-canary.yaml
+apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfigPool
 metadata:
   name: workerpool-canary


### PR DESCRIPTION
apiVersionを書かないと下記のエラーがでます。

```
oc create -f worker-canary.yaml

error: resource mapping not found for name: "workerpool-canary" namespace: "" from "worker-canary.yaml": no matches for kind "MachineConfigPool" in version "" ensure CRDs are installed first
```